### PR TITLE
Fix crash on socket errors during disconnect leaving orphan transactions

### DIFF
--- a/src/efirebirdsql_protocol.erl
+++ b/src/efirebirdsql_protocol.erl
@@ -132,21 +132,28 @@ connect(Host, Username, Password, Database, Options) ->
 -spec close(conn()) -> {ok, conn()} | {error, integer(), binary(), conn()}.
 close(Conn) ->
     ?DEBUG_FORMAT("close() db_handle=~p~n", [Conn#conn.db_handle]),
-    efirebirdsql_socket:send(Conn,
-        efirebirdsql_op:op_detach(Conn#conn.db_handle)),
-    case efirebirdsql_op:get_response(Conn) of
-    {op_response, _, _} ->
-        gen_tcp:close(Conn#conn.sock),
-        {ok, Conn#conn{sock=undefined}};
-    {error, ErrNo, Msg} ->
-        if
-            ErrNo =:= 335544357 ->  % cannot disconnect database with open transactions
-                gen_tcp:close(Conn#conn.sock),
-                {ok, Conn#conn{sock=undefined}};
-            ErrNo =/= 335544357 ->
-                ?DEBUG_FORMAT("close() error ~p~p~n", [ErrNo, Msg]),
-                {error, ErrNo, Msg, Conn}
-        end
+    %% The op_detach exchange is best effort: after a request timeout the
+    %% socket can be left with a pending recv ({error, ealready}) or in a
+    %% otherwise broken state, and the exchange fails. The socket must be
+    %% closed regardless, so the server drops the attachment and rolls back
+    %% open transactions immediately instead of leaving them orphaned.
+    Response = try
+        efirebirdsql_socket:send(Conn,
+            efirebirdsql_op:op_detach(Conn#conn.db_handle)),
+        efirebirdsql_op:get_response(Conn)
+    catch
+        _Class:Reason ->
+            ?DEBUG_FORMAT("close() detach failed ~p:~p~n", [_Class, Reason]),
+            {error, detach_failed, Reason}
+    end,
+    gen_tcp:close(Conn#conn.sock),
+    case Response of
+    {error, ErrNo, Msg} when ErrNo =/= 335544357, ErrNo =/= detach_failed ->
+        %% 335544357: cannot disconnect database with open transactions
+        ?DEBUG_FORMAT("close() error ~p~p~n", [ErrNo, Msg]),
+        {error, ErrNo, Msg, Conn#conn{sock=undefined}};
+    _ ->
+        {ok, Conn#conn{sock=undefined}}
     end.
 
 %% Transaction

--- a/src/efirebirdsql_socket.erl
+++ b/src/efirebirdsql_socket.erl
@@ -18,9 +18,12 @@ recv(_Conn, Len) when Len =:= 0 ->
 recv(Conn, Len) when Conn#conn.read_state =:= undefined ->
     gen_tcp:recv(Conn#conn.sock, Len);
 recv(Conn, Len) ->
-    {T, Encrypted} = gen_tcp:recv(Conn#conn.sock, Len),
-    Message = crypto:crypto_update(Conn#conn.read_state, Encrypted),
-    {T, Message}.
+    case gen_tcp:recv(Conn#conn.sock, Len) of
+        {ok, Encrypted} ->
+            {ok, crypto:crypto_update(Conn#conn.read_state, Encrypted)};
+        {error, _Reason} = Error ->
+            Error
+    end.
 
 recv_align(Conn, Len) ->
     {T, V} = recv(Conn, Len),

--- a/test/efirebirdsql_socket_tests.erl
+++ b/test/efirebirdsql_socket_tests.erl
@@ -1,0 +1,42 @@
+%%% The MIT License (MIT)
+%%% Copyright (c) 2016-2021 Hajime Nakagami<nakagami@gmail.com>
+
+-module(efirebirdsql_socket_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("efirebirdsql.hrl").
+
+%% A socket error during recv (eg. {error, closed} after the server went
+%% away, or {error, ealready} when a previous recv timed out and is still
+%% pending) must be returned as is. Before the fix the error reason atom
+%% was passed to crypto:crypto_update/2 as if it were wire data, crashing
+%% with badarg when wire encryption was enabled.
+recv_error_returns_error_tuple_test() ->
+    {Sock, Listen} = broken_connection(),
+    Conn = #conn{
+        sock=Sock,
+        read_state=crypto:crypto_init(rc4, <<"0123456789abcdef">>, false)},
+    ?assertEqual({error, closed}, efirebirdsql_socket:recv(Conn, 4)),
+    gen_tcp:close(Sock),
+    gen_tcp:close(Listen).
+
+%% close/1 must close the socket even if the op_detach exchange fails
+%% (broken socket after a request timeout). Otherwise the server keeps the
+%% attachment alive and its open transactions are left orphaned until the
+%% dead TCP connection is detected.
+close_closes_socket_on_broken_connection_test() ->
+    {Sock, Listen} = broken_connection(),
+    Conn = #conn{sock=Sock, db_handle=0},
+    {ok, Conn2} = efirebirdsql_protocol:close(Conn),
+    ?assertEqual(undefined, Conn2#conn.sock),
+    ?assertEqual(undefined, erlang:port_info(Sock)),
+    gen_tcp:close(Listen).
+
+%% client socket whose peer is already gone
+broken_connection() ->
+    {ok, Listen} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listen),
+    {ok, Sock} = gen_tcp:connect("localhost", Port, [binary, {active, false}]),
+    {ok, Peer} = gen_tcp:accept(Listen),
+    ok = gen_tcp:close(Peer),
+    {Sock, Listen}.


### PR DESCRIPTION
## Problem

When a request times out (e.g. the client gives up on a slow query and `DBConnection` in Elixir calls `Firebirdex.Connection.disconnect/2`, which ends up in `efirebirdsql_protocol:close/1`), the socket can be left in a broken state — `gen_tcp:recv` returns `{error, ealready}` because the previous `recv` is still pending, or `{error, closed}` if the peer went away. Two issues compound here:

1. **`efirebirdsql_socket:recv/2`** (wire encryption path) does not distinguish success from failure:

   ```erlang
   {T, Encrypted} = gen_tcp:recv(Conn#conn.sock, Len),
   Message = crypto:crypto_update(Conn#conn.read_state, Encrypted),
   ```

   `{error, ealready}` matches `{T, Encrypted}`, so the error *reason atom* is fed to `crypto:crypto_update/2` as if it were wire data, crashing with `badarg` (`api_ng.c: "expected binary"`). Without wire encryption the same situation crashes slightly later with a `badmatch` in `get_response/1`.

2. **`efirebirdsql_protocol:close/1`** sends `op_detach` and waits for the response *before* closing the socket. When that exchange crashes (case above), the function aborts before `gen_tcp:close/1` ever runs. The server side keeps the attachment — and any open transaction — alive until the TCP stack eventually detects the dead connection, which can take a very long time. Those **orphan transactions** block garbage collection (OAT stops advancing) and degrade the server.

## Fix

- `recv/2` now returns `{error, Reason}` as is instead of feeding it to crypto.
- `close/1` performs the `op_detach` exchange as best effort (`try/catch`) and closes the socket **unconditionally**. Even when detach fails, the TCP FIN makes the server drop the attachment and roll back its open transactions immediately.

Return values for the normal paths are unchanged.

## How to test

Two eunit tests are included (`test/efirebirdsql_socket_tests.erl`); both fail against the current code and pass with this patch:

- `recv_error_returns_error_tuple_test` — a recv on a connection whose peer is gone must return `{error, closed}`, not crash in `crypto_update`.
- `close_closes_socket_on_broken_connection_test` — `close/1` on a broken connection must still close the port and return `{ok, Conn}`.

Reproduced end to end against a real Firebird server (via Elixir `firebirdex`): force a request timeout on a slow query, then watch `MON$TRANSACTIONS` — before the patch the dying connection crashes in `crypto_update`/`get_response` and its transaction stays active (orphaned); with the patch the server rolls it back immediately after the disconnect.
