### PR TITLE
Add configurable isc_tpb_lock_timeout connection option

### DIFF
--- a/include/efirebirdsql.hrl
+++ b/include/efirebirdsql.hrl
@@ -28,7 +28,8 @@
     db_handle,
     trans_handle,
     accept_version,
-    timezone :: string() | nil
+    timezone :: string() | nil,
+    lock_timeout :: integer() | nil   %% isc_tpb_lock_timeout seconds, nil = disabled
 }).
 
 -type conn() :: #conn{}.

--- a/src/efirebirdsql_protocol.erl
+++ b/src/efirebirdsql_protocol.erl
@@ -6,7 +6,7 @@
 %%% -define(DEBUG_FORMAT(X,Y), io:format(standard_error, X, Y)).
 -define(DEBUG_FORMAT(X,Y), ok).
 
--export([connect/5, close/1, begin_transaction/2]).
+-export([connect/5, close/1, begin_transaction/2, tpb/2]).
 -export([unallocate_statement/1, allocate_statement/1, allocate_statement/2]).
 -export([prepare_statement/3, prepare_statement/2, free_statement/3]).
 -export([columns/1]).
@@ -100,7 +100,8 @@ connect(Host, Username, Password, Database, Options) ->
             client_public=Public,
             auth_plugin=proplists:get_value(auth_plugin, Options, "Srp256"),
             wire_crypt=proplists:get_value(wire_crypt, Options, true),
-            timezone=proplists:get_value(timezone, Options, nil)
+            timezone=proplists:get_value(timezone, Options, nil),
+            lock_timeout=proplists:get_value(lock_timeout, Options, nil)
         },
         case Conn#conn.auto_commit of 
             true ->
@@ -157,17 +158,35 @@ close(Conn) ->
     end.
 
 %% Transaction
+
+%% TPB (Transaction Parameter Buffer): ISOLATION_LEVEL_READ_COMMITTED.
+%% isc_tpb_version3, isc_tpb_write, isc_tpb_wait, isc_tpb_read_committed, isc_tpb_rec_version
+%% Optionally appends isc_tpb_lock_timeout when LockTimeout is an integer (seconds):
+%% a transaction blocked on a lock conflict then fails fast instead of waiting
+%% indefinitely. nil (the default) preserves the historical behavior (wait forever).
+-spec tpb(boolean(), integer() | nil) -> [integer()].
+tpb(AutoCommit, LockTimeout) ->
+    Base = case AutoCommit of
+        true -> [3, 9, 6, 15, 17, 16];   %% + isc_tpb_autocommit
+        false -> [3, 9, 6, 15, 17]
+    end,
+    Base ++ lock_timeout_tpb(LockTimeout).
+
+%% isc_tpb_lock_timeout (21) + length 4 + seconds (32-bit little-endian).
+-spec lock_timeout_tpb(integer() | nil) -> [integer()].
+lock_timeout_tpb(nil) -> [];
+lock_timeout_tpb(Seconds) when is_integer(Seconds) ->
+    [21, 4,
+     Seconds band 16#FF,
+     (Seconds bsr 8) band 16#FF,
+     (Seconds bsr 16) band 16#FF,
+     (Seconds bsr 24) band 16#FF].
+
 -spec begin_transaction(boolean(), conn()) -> {ok, conn()} | {error, integer(), binary(), conn()}.
 begin_transaction(AutoCommit, Conn) ->
     ?DEBUG_FORMAT("begin_transaction() db_handle=~p~n", [Conn#conn.db_handle]),
-    %% ISOLATION_LEVEL_READ_COMMITED
-    %% isc_tpb_version3,isc_tpb_write,isc_tpb_wait,isc_tpb_read_committed,isc_tpb_rec_version
-    Tpb = if
-        AutoCommit =:= true -> [3, 9, 6, 15, 17, 16];   % +isc_tpb_autocommit
-        AutoCommit =:= false -> [3, 9, 6, 15, 17]
-        end,
     efirebirdsql_socket:send(Conn,
-        efirebirdsql_op:op_transaction(Conn#conn.db_handle, Tpb)),
+        efirebirdsql_op:op_transaction(Conn#conn.db_handle, tpb(AutoCommit, Conn#conn.lock_timeout))),
     case efirebirdsql_op:get_response(Conn) of
     {op_response, Handle, _} -> {ok, Conn#conn{trans_handle=Handle}};
     {error, ErrNo, Msg} -> {error, ErrNo, Msg, Conn}

--- a/test/efirebirdsql_protocol_tests.erl
+++ b/test/efirebirdsql_protocol_tests.erl
@@ -115,3 +115,15 @@ connect_error_test() ->
     {error, ErrNo, Reason, _Conn} = efirebirdsql_protocol:connect("localhost", os:getenv("ISC_USER", "sysdba"), os:getenv("ISC_PASSWORD", "masterkey"), "something_wrong_database", []),
     ?assertEqual(ErrNo, 335544734),
     ?assertNotEqual(Reason, nil).
+
+lock_timeout_tpb_test() ->
+    %% nil (default): no isc_tpb_lock_timeout, historical behavior preserved.
+    ?assertEqual([3, 9, 6, 15, 17], efirebirdsql_protocol:tpb(false, nil)),
+    ?assertEqual([3, 9, 6, 15, 17, 16], efirebirdsql_protocol:tpb(true, nil)),
+    %% integer seconds: appends isc_tpb_lock_timeout (21) + length 4 + value (little-endian).
+    ?assertEqual([21, 4, 12, 0, 0, 0], lists:nthtail(5, efirebirdsql_protocol:tpb(false, 12))),
+    ?assertEqual([21, 4, 12, 0, 0, 0], lists:nthtail(6, efirebirdsql_protocol:tpb(true, 12))),
+    %% values >255 are encoded across the 4 little-endian bytes (e.g. 300 = 16#012C).
+    ?assertEqual([21, 4, 16#2C, 16#01, 0, 0], lists:nthtail(5, efirebirdsql_protocol:tpb(false, 300))),
+    %% read committed base is preserved (version3, write, wait, read_committed, rec_version)
+    ?assertEqual([3, 9, 6, 15, 17], lists:sublist(efirebirdsql_protocol:tpb(false, 12), 5)).


### PR DESCRIPTION
## Motivation

When a transaction is blocked on a lock conflict, Firebird's default WAIT behavior makes it wait **indefinitely** for the lock to be released. There is currently no way to bound that wait from this driver: a client that gives up on its side (timeout, disconnect) leaves the transaction orphaned in Firebird, still holding its locks, until it's cleaned up.

Firebird's Transaction Parameter Buffer already supports `isc_tpb_lock_timeout`, which makes a blocked transaction fail cleanly with a lock-timeout error after N seconds instead of waiting forever. This PR exposes it as a connection option so callers can opt into bounded lock waits.

## What changed

- **New connection option `lock_timeout`** (integer, seconds). Read from the `connect/5` options and stored on the `#conn{}` record (`include/efirebirdsql.hrl`).
- **`begin_transaction/2`** now builds the TPB via a new `tpb/2` helper that appends `isc_tpb_lock_timeout` when `lock_timeout` is set. Encoding follows the TPB format: tag `21`, length `4`, value as a 32-bit little-endian integer (seconds).
- **`tpb/2` is exported** so the parameter buffer can be unit-tested directly, without a server round-trip.

```erlang
%% before: bounded only by the read-committed base TPB
[3, 9, 6, 15, 17]            %% isc_tpb_version3, write, wait, read_committed, rec_version

%% with lock_timeout = 12 (seconds):
[3, 9, 6, 15, 17, 21, 4, 12, 0, 0, 0]
```

## Backwards compatibility

The option defaults to `nil` (disabled). When unset, `tpb/2` emits the **exact same TPB as before** — no extra bytes, no behavior change for existing users. Locks still wait forever unless the caller explicitly opts in. Based on `REL_0_9_12`.

## Testing

Added `lock_timeout_tpb_test/0` (eunit), all assertions against `tpb/2` so they run without a server:

- `nil` → unchanged TPB for both auto-commit and non-auto-commit transactions.
- integer → `isc_tpb_lock_timeout` appended with the correct little-endian bytes, including values > 255 (e.g. `300` → `2C 01 00 00`).
- the read-committed base (`version3, write, wait, read_committed, rec_version`) is preserved in all cases.
